### PR TITLE
chore: use absolute path in shell scripts

### DIFF
--- a/shell/commands/build
+++ b/shell/commands/build
@@ -10,6 +10,8 @@
 
 #. get default version from package.json? use jq to extract?
 
+repo_root="$(dirname "$(dirname "$(dirname "$(realpath "$0")")")")"
+
 usage="
 Usage: l99 build SERVICE
 
@@ -34,7 +36,7 @@ fi
 
 SERVICE=$1
 # VERSION=$2
-VERSION=$(cat .l99_version)
+VERSION="$(cat "$repo_root/.l99_version")"
 # note: arm/v7 is 32bit for older pi's
 # need arm64/v8 ?
 # PLATFORMS=${3:-"amd64 arm64"}
@@ -43,10 +45,10 @@ USERNAME=ladder99
 
 # create a multiplatform buildx builder
 # do this each time, per answer by guy with 200k rep in 2022-02 -
-# The easy button is to use the binaries from the multiarch image. This is good in 
-# CI if you have a dedicated VM (less ideal if you are modifying the host used by 
-# other builds). However if you reboot, it breaks until you run the container again. 
-# And it requires you to remember to update it for any upstream patches. 
+# The easy button is to use the binaries from the multiarch image. This is good in
+# CI if you have a dedicated VM (less ideal if you are modifying the host used by
+# other builds). However if you reboot, it breaks until you run the container again.
+# And it requires you to remember to update it for any upstream patches.
 # So I wouldn't recommend it for a long running build host.
 # from https://stackoverflow.com/questions/60080264/docker-cannot-build-multi-platform-images-with-docker-buildx
 docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
@@ -62,7 +64,7 @@ for arch in amd64 arm64 ; do
     --platform linux/$arch \
     --output type=docker \
     --tag $USERNAME/$SERVICE:$VERSION-${arch} \
-    services/$SERVICE/
+    "$repo_root/services/$SERVICE"
 done
 
 echo "Combining images and pushing to Docker Hub..."
@@ -70,4 +72,4 @@ docker buildx build \
 --platform linux/amd64,linux/arm64 \
 --tag $USERNAME/$SERVICE:$VERSION \
 --push \
-services/$SERVICE/
+"$repo_root/services/$SERVICE"

--- a/shell/commands/build-parallel
+++ b/shell/commands/build-parallel
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+repo_root="$(dirname "$(dirname "$(dirname "$(realpath "$0")")")")"
+
 usage="
 Usage: l99 build-parallel SERVICE [PLATFORMS]
 
@@ -26,22 +28,22 @@ fi
 
 SERVICE=$1
 # VERSION=$2
-VERSION=$(cat .l99_version)
+VERSION="$(cat "$repo_root/.l99_version")"
 # arm/v7 is 32bit for older pi's
 # PLATFORMS=${3:-"linux/amd64,linux/arm64,linux/arm/v7"}
 PLATFORMS=${3:-"linux/amd64,linux/arm64"}
 
 USERNAME=ladder99
 TAG=$USERNAME/$SERVICE:$VERSION
-SERVICE_DIR=services/$SERVICE
+SERVICE_DIR="$repo_root/services/$SERVICE"
 
 # create a multiplatform buildx builder
 # see https://stackoverflow.com/questions/60080264/docker-cannot-build-multi-platform-images-with-docker-buildx
 # do this each time, per answer by guy with 200k rep in 2022-02 -
-# The easy button is to use the binaries from the multiarch image. This is good in 
-# CI if you have a dedicated VM (less ideal if you are modifying the host used by 
-# other builds). However if you reboot, it breaks until you run the container again. 
-# And it requires you to remember to update it for any upstream patches. 
+# The easy button is to use the binaries from the multiarch image. This is good in
+# CI if you have a dedicated VM (less ideal if you are modifying the host used by
+# other builds). However if you reboot, it breaks until you run the container again.
+# And it requires you to remember to update it for any upstream patches.
 # So I wouldn't recommend it for a long running build host.
 docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 docker buildx rm l99builder

--- a/shell/commands/compose
+++ b/shell/commands/compose
@@ -2,6 +2,8 @@
 
 # run docker compose command
 
+repo_root="$(dirname "$(dirname "$(dirname "$(realpath "$0")")")")"
+
 usage="
 Usage: l99 compose COMMAND [OPTIONS] [SERVICES]
 
@@ -27,8 +29,8 @@ if [ $# -eq 0 ]; then
 fi
 
 # get setup folder
-SETUP=$(cat .l99_setup)
-SETUP_FOLDER=setups/$SETUP
+SETUP="$(cat "$repo_root/.l99_setup")"
+SETUP_FOLDER="$repo_root/setups/$SETUP"
 
 # handle missing setup folder
 if [ ! -e $SETUP_FOLDER ]; then
@@ -70,8 +72,8 @@ elif [ "$COMMAND" = "logs" ]; then
 fi
 
 # file paths
-COMPOSE=services/docker-compose.yaml
-COMPOSE_PROD=services/docker-compose.prod.yaml
+COMPOSE="$repo_root/services/docker-compose.yaml"
+COMPOSE_PROD="$repo_root/services/docker-compose.prod.yaml"
 OVERRIDES=$SETUP_FOLDER/services/docker-compose.yaml
 ENVFILE=$SETUP_FOLDER/.env
 ENVFILE_EXAMPLE=$SETUP_FOLDER/.env-example
@@ -118,7 +120,7 @@ if [[ $BUILD ]]; then
 fi
 
 # make and run cmd
-# note: --project-name specifies project name, as shown in docker management consoles - 
+# note: --project-name specifies project name, as shown in docker management consoles -
 # otherwise it uses the parent folder name (ie 'services').
 CMD="
 export SETUP=$SETUP &&

--- a/shell/commands/dev
+++ b/shell/commands/dev
@@ -1,10 +1,12 @@
 #!/bin/bash
 
+repo_root="$(dirname "$(dirname "$(dirname "$(realpath "$0")")")")"
+
 usage="
 Usage: l99 dev [SERVICES]
 
 Start a docker service or services using their profile name(s).
-Builds the image locally from the service Dockerfile.
+Builds the image locallzy from the service Dockerfile.
 See also l99 start.
 
 SERVICES      space-delim list of services or profiles to start
@@ -27,7 +29,7 @@ fi
 SERVICES=${*:-base}
 
 # make cmd and run it
-CMD="l99 compose up --build $SERVICES"
+CMD="$repo_root/l99 compose up --build $SERVICES"
 
 echo "$CMD"
 bash -c "$CMD"

--- a/shell/commands/disk
+++ b/shell/commands/disk
@@ -2,9 +2,11 @@
 
 # Print disk usage for current setup.
 
+repo_root="$(dirname "$(dirname "$(dirname "$(realpath "$0")")")")"
+
 # get setup folder
-SETUP=$(cat .l99_setup)
-SETUP_DIR=setups/$SETUP
+SETUP="$(cat "$repo_root/.l99_setup")"
+SETUP_DIR="$repo_root/setups/$SETUP"
 
 # note: sudo isn't always available, eg in git bash environment, so test
 if hash sudo 2>/dev/null; then
@@ -28,4 +30,4 @@ $SUDO du -d1 -h setups
 echo
 
 echo "Docker volumes for '$SETUP' setup"
-$SUDO du -d1 -h $SETUP_DIR/volumes/
+$SUDO du -d1 -h "$SETUP_DIR/volumes"

--- a/shell/commands/download
+++ b/shell/commands/download
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+repo_root="$(dirname "$(dirname "$(dirname "$(realpath "$0")")")")"
+
 usage="
 Usage: l99 download SETUP
 
@@ -20,13 +22,13 @@ SETUP=$1
 shift
 
 # get setup folder, eg 'setups/test'
-SETUP_FOLDER=setups/$SETUP
+SETUP_FOLDER="$repo_root/setups/$SETUP"
 
 if [ -e $SETUP_FOLDER ]; then
     echo Setup folder \'$SETUP_FOLDER\' already exists. Please try again.
     exit 1
 fi
 
-git clone https://github.com/Ladder99/setup-$SETUP $SETUP_FOLDER \
-&& echo $SETUP > .l99_setup \
-&& shell/commands/using
+git clone https://github.com/Ladder99/setup-$SETUP "$SETUP_FOLDER" \
+&& echo $SETUP > "$repo_root/.l99_setup" \
+&& "$repo_root/shell/commands/using"

--- a/shell/commands/init
+++ b/shell/commands/init
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+repo_root="$(dirname "$(dirname "$(dirname "$(realpath "$0")")")")"
+
 usage="
 Usage: l99 init SETUP
 
@@ -16,14 +18,14 @@ if [ $# -eq 0 ]; then
 fi
 
 # source folder
-EXAMPLE=setups/example
+EXAMPLE="$repo_root/setups/example"
 
 # get setup name
 SETUP=$1
 shift
 
 # get setup folder
-SETUP_FOLDER=setups/$SETUP
+SETUP_FOLDER="$repo_root/setups/$SETUP"
 
 # check if setup dir already exists
 if [ -d "$SETUP_FOLDER" ]; then
@@ -36,8 +38,8 @@ fi
 echo
 echo "Copying from '$EXAMPLE'..."
 
-# need to specify everything explicitly here - 
-# alternative is installing rsync on gitbash, or ignoring cp errors, 
+# need to specify everything explicitly here -
+# alternative is installing rsync on gitbash, or ignoring cp errors,
 # or using sudo to cp everything including potentially large pg folders.
 # so, will need to keep this up-to-date if add more to the example folder!
 
@@ -55,14 +57,14 @@ mkdir $SETUP_FOLDER \
 && cp $EXAMPLE/services/docker-compose.yaml $SETUP_FOLDER/services \
 && cp $EXAMPLE/README.md $SETUP_FOLDER \
 && cp $EXAMPLE/setup.yaml $SETUP_FOLDER \
-&& shell/commands/use $SETUP \
+&& "$repo_root/shell/commands/use" $SETUP \
 && echo "Done. Try 'l99 start'"
 
 # old:
 # need `2>/dev/null || :` to suppress the error msgs and errors in cp,
 # see https://serverfault.com/a/153893/211025.
 # but
-# rsync has an --exclude param, but installing rsync on git bash for windows is complex - 
+# rsync has an --exclude param, but installing rsync on git bash for windows is complex -
 #  https://superuser.com/questions/701141/how-to-add-more-commands-to-git-bash
 # sudo cp -R setups/example $SETUP_FOLDER \
 # cp -R setups/example $SETUP_FOLDER 2>/dev/null || : \

--- a/shell/commands/list
+++ b/shell/commands/list
@@ -1,3 +1,5 @@
 #!/bin/bash
 
-l99 status $*
+repo_root="$(dirname "$(dirname "$(dirname "$(realpath "$0")")")")"
+
+"$repo_root/l99" status "$@"

--- a/shell/commands/restart
+++ b/shell/commands/restart
@@ -2,6 +2,8 @@
 
 # restart services
 
+repo_root="$(dirname "$(dirname "$(dirname "$(realpath "$0")")")")"
+
 usage="
 Usage: l99 restart [SERVICES]
 
@@ -19,6 +21,6 @@ fi
 SERVICES=$*
 
 echo "Stopping services..." \
-&& l99 stop $SERVICES \
+&& "$repo_root/l99" stop $SERVICES \
 && echo "Starting services..." \
-&& l99 start $SERVICES
+&& "$repo_root/l99" start $SERVICES

--- a/shell/commands/start
+++ b/shell/commands/start
@@ -2,6 +2,8 @@
 
 # run ladder99 pipeline using prebuilt images from docker hub.
 
+repo_root="$(dirname "$(dirname "$(dirname "$(realpath "$0")")")")"
+
 usage="
 Usage: l99 start [SERVICES]
 
@@ -30,7 +32,7 @@ SERVICES=${*:-base}
 
 # make cmd and run it
 # 'l99 compose up' runs with --no-build by default
-CMD="l99 compose up $SERVICES"
+CMD="$repo_root/l99 compose up $SERVICES"
 
 echo "$CMD"
 bash -c "$CMD"

--- a/shell/commands/update
+++ b/shell/commands/update
@@ -2,9 +2,11 @@
 
 # update Ladder99 pipeline and client code
 
+repo_root="$(dirname "$(dirname "$(dirname "$(realpath "$0")")")")"
+
 # get setup folder
-SETUP=$(cat .l99_setup)
-SETUP_FOLDER=setups/$SETUP
+SETUP="$(cat "$repo_root/.l99_setup")"
+SETUP_FOLDER="$repo_root/setups/$SETUP"
 
 # handle missing setup folder
 if [ ! -e $SETUP_FOLDER ]; then
@@ -16,11 +18,11 @@ fi
 # git pull ladder99 repo then setup repo
 # set credential cache while we're at it so user doesn't have to
 # keep entering passcode - 360000=100h.
-# note: we do both pulls in same command so if first fails, won't do second - 
+# note: we do both pulls in same command so if first fails, won't do second -
 # because it was easy to miss the failed first command.
 echo "Updating ladder99 repo..."
 git pull \
 && echo \
 && echo "Updating '$SETUP' repo (and setting credential cache timeout while we're at it)..." \
-&& (cd $SETUP_FOLDER && git config credential.helper 'cache --timeout=360000') \
-&& (cd $SETUP_FOLDER && git pull)
+&& git -C "$SETUP_FOLDER" config credential.helper 'cache --timeout=360000' \
+&& git -C "$SETUP_FOLDER" pull

--- a/shell/commands/use
+++ b/shell/commands/use
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+repo_root="$(dirname "$(dirname "$(dirname "$(realpath "$0")")")")"
+
 usage="
 Usage: l99 use SETUP
 
@@ -19,15 +21,15 @@ SETUP=$1
 shift
 
 # get setup folder
-SETUP_FOLDER=setups/$SETUP
+SETUP_FOLDER="$repo_root/setups/$SETUP"
 
 # handle missing setup folder
-if [ ! -e $SETUP_FOLDER ]; then
+if [ ! -e "$SETUP_FOLDER" ]; then
     echo "Setup folder '$SETUP_FOLDER' does not exist. Please try again."
     exit 1
 fi
 
 # save setup to a file
-echo $SETUP > .l99_setup
+echo $SETUP > "$repo_root/.l99_setup"
 
-shell/commands/using
+"$repo_root/shell/commands/using"

--- a/shell/commands/using
+++ b/shell/commands/using
@@ -1,6 +1,8 @@
 #!/bin/bash
 
+repo_root="$(dirname "$(dirname "$(dirname "$(realpath "$0")")")")"
+
 # report the currently used setup
 
-SETUP=$(cat .l99_setup)
+SETUP=$(cat "$repo_root/.l99_setup")
 echo "Using '$SETUP' for Ladder99 setup, as found in the 'setups' folder."

--- a/shell/install/cli
+++ b/shell/install/cli
@@ -3,18 +3,20 @@
 # install ladder99 cli (l99) by amending the ~/.bashrc file.
 # works on linux bash and git bash for windows.
 
+repo_root="$(dirname "$(dirname "$(dirname "$(realpath "$0")")")")"
+
 echo "Adding PATH extension and L99 variables to ~/.bashrc..."
 
 # amend the .bashrc file
 echo >> ~/.bashrc
 echo "# added by ladder99 $(date -Iseconds)" >> ~/.bashrc
-echo "export PATH=\$PATH:`pwd`/shell" >> ~/.bashrc
-echo "export L99_HOME=`pwd`" >> ~/.bashrc
+echo "export PATH=\"\$PATH:$repo_root/shell\"" >> ~/.bashrc
+echo "export L99_HOME='$repo_root'" >> ~/.bashrc
 echo "export L99_SETUP" >> ~/.bashrc
 
 # use the configuration in the setups/example folder
 # (writes to .l99_setup file)
-shell/commands/use example
+"$repo_root/shell/commands/use" example
 
 echo "Done."
 echo "Please run the file by typing in 'source ~/.bashrc', or logout and log back in."

--- a/shell/l99
+++ b/shell/l99
@@ -7,6 +7,8 @@
 # some discussion here
 # https://unix.stackexchange.com/questions/379464/why-does-this-script-work-in-the-terminal-but-not-from-a-file
 
+repo_root="$(dirname "$(dirname "$(dirname "$(realpath "$0")")")")"
+
 usage="
 Usage: l99 COMMAND [PARAMS]
 
@@ -41,23 +43,23 @@ Examples
     l99 init my-company
 "
 
+L99_HOME="${$L99_HOME:-$repo_root}"
+
 if [ "$L99_HOME" = "" ]; then
     echo "Please install the Ladder99 cli using the install script, i.e. run 'shell/install'."
     exit 1
 fi
 
-cd $L99_HOME
-
 # show help if count of params is zero
 if [ $# -eq 0 ]; then
     echo "$usage"
-    shell/commands/using
+    "$repo_root/shell/commands/using"
     exit
 fi
 
 # get command
 CMD=$1 # eg 'start'
-CMD_PATH=shell/commands/$CMD # eg 'shell/commands/start'
+CMD_PATH="$repo_root/shell/commands/$CMD" # eg 'shell/commands/start'
 shift
 
 # get paramters


### PR DESCRIPTION
After this change, we can run `l99` or `shell/install/cli` from any CWD.