### PR TITLE
chore: fix some issues with the absolute paths in shell scripts

### DIFF
--- a/shell/commands/dev
+++ b/shell/commands/dev
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-repo_root="$(dirname "$(dirname "$(dirname "$(realpath "$0")")")")"
+scripts_root="$(dirname "$(dirname "$(dirname "$(realpath "$0")")")")/shell"
 
 usage="
 Usage: l99 dev [SERVICES]
@@ -29,7 +29,7 @@ fi
 SERVICES=${*:-base}
 
 # make cmd and run it
-CMD="$repo_root/l99 compose up --build $SERVICES"
+CMD="$scripts_root/l99 compose up --build $SERVICES"
 
 echo "$CMD"
 bash -c "$CMD"

--- a/shell/commands/list
+++ b/shell/commands/list
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-repo_root="$(dirname "$(dirname "$(dirname "$(realpath "$0")")")")"
+scripts_root="$(dirname "$(dirname "$(dirname "$(realpath "$0")")")")/shell"
 
-"$repo_root/l99" status "$@"
+"$scripts_root/l99" status "$@"

--- a/shell/commands/restart
+++ b/shell/commands/restart
@@ -2,7 +2,7 @@
 
 # restart services
 
-repo_root="$(dirname "$(dirname "$(dirname "$(realpath "$0")")")")"
+scripts_root="$(dirname "$(dirname "$(dirname "$(realpath "$0")")")")/shell"
 
 usage="
 Usage: l99 restart [SERVICES]
@@ -21,6 +21,6 @@ fi
 SERVICES=$*
 
 echo "Stopping services..." \
-&& "$repo_root/l99" stop $SERVICES \
+&& "$scripts_root/l99" stop $SERVICES \
 && echo "Starting services..." \
-&& "$repo_root/l99" start $SERVICES
+&& "$scripts_root/l99" start $SERVICES

--- a/shell/commands/start
+++ b/shell/commands/start
@@ -2,7 +2,7 @@
 
 # run ladder99 pipeline using prebuilt images from docker hub.
 
-repo_root="$(dirname "$(dirname "$(dirname "$(realpath "$0")")")")"
+scripts_root="$(dirname "$(dirname "$(dirname "$(realpath "$0")")")")/shell"
 
 usage="
 Usage: l99 start [SERVICES]
@@ -32,7 +32,7 @@ SERVICES=${*:-base}
 
 # make cmd and run it
 # 'l99 compose up' runs with --no-build by default
-CMD="$repo_root/l99 compose up $SERVICES"
+CMD="$scripts_root/l99 compose up $SERVICES"
 
 echo "$CMD"
 bash -c "$CMD"

--- a/shell/l99
+++ b/shell/l99
@@ -43,7 +43,7 @@ Examples
     l99 init my-company
 "
 
-L99_HOME="${$L99_HOME:-$repo_root}"
+L99_HOME="${L99_HOME:-$repo_root}"
 
 if [ "$L99_HOME" = "" ]; then
     echo "Please install the Ladder99 cli using the install script, i.e. run 'shell/install'."
@@ -53,13 +53,13 @@ fi
 # show help if count of params is zero
 if [ $# -eq 0 ]; then
     echo "$usage"
-    "$repo_root/shell/commands/using"
+    "$L99_HOME/shell/commands/using"
     exit
 fi
 
 # get command
 CMD=$1 # eg 'start'
-CMD_PATH="$repo_root/shell/commands/$CMD" # eg 'shell/commands/start'
+CMD_PATH="$L99_HOME/shell/commands/$CMD" # eg 'shell/commands/start'
 shift
 
 # get paramters


### PR DESCRIPTION
I forgot to add `scripts/` in some scripts and there was an extra `$` in `l99`.

This should fix #233.