### PR TITLE
docs: update the RTD config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,19 +1,16 @@
 # Read the Docs configuration file
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
-# Required
-version: 2
+build:
+  os: ubuntu-22.04
+  tools:
+    python: '3.12'
 
-# Build documentation in the docs/ directory with Sphinx
+python:
+  install:
+    - requirements: docs/requirements.txt
+
 sphinx:
   configuration: docs/conf.py
 
-# # Optionally build your docs in additional formats such as PDF
-# formats:
-#   - pdf
-
-# Optionally set the version of Python and requirements required to build your docs
-python:
-  version: 3.7
-  install:
-    - requirements: docs/requirements.txt
+version: 2


### PR DESCRIPTION
We need to update the Read the Docs configuration, otherwise the docs build will fail on the RTD server.